### PR TITLE
Added ability to globally set additional curl_setopt

### DIFF
--- a/lib/transloadit/CurlRequest.php
+++ b/lib/transloadit/CurlRequest.php
@@ -2,12 +2,12 @@
 namespace transloadit;
 
 class CurlRequest {
-  private static $curlEnvironmentOptions = array();
   public $method = 'GET';
   public $url = null;
   public $headers = array();
   public $fields = array();
   public $files = array();
+  public $curlOptions = array();
 
   // Apply all passed attributes to the instance
   public function __construct($attributes = array()) {
@@ -24,7 +24,11 @@ class CurlRequest {
       $url .= '?'.http_build_query($this->fields);
     }
 
-    $options = self::$curlEnvironmentOptions + array(
+    if(!is_array($this->curlOptions)){
+        $this->curlOptions = array($this->curlOptions);
+    }
+
+    $options = $this->curlOptions + array(
       CURLOPT_RETURNTRANSFER => true,
       CURLOPT_CUSTOMREQUEST => $this->method,
       CURLOPT_URL => $url,
@@ -66,8 +70,5 @@ class CurlRequest {
 
     return $response;
   }
-  
-  public static function setCurlEnvironmentOptions(array $curlEnvironmentOptions = array()) {
-    self::$curlEnvironmentOptions = $curlEnvironmentOptions;
-  }
+
 }


### PR DESCRIPTION
This will allow a user to set additional curl_setopt globally for their env. For instant, when developing locally, a developer might need to set 'CURLOPT_SSL_VERIFYPEER' to false to avoid unsigned ssl errors.
