### PR TITLE
Implement waitForCompletion to allow waiting for transcoding results

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,13 @@ $Transloadit->createAssemblyForm(array(
 Sends a new assembly request to Transloadit. This is the preferred way of
 uploading files from your server.
 
-`$options` is an array of `TransloaditRequest` properties to be used.
+`$options` is an array of `TransloaditRequest` properties to be used with the exception that you can
+also use the `waitForCompletion` option here:
+
+`waitForCompletion` is a boolean (default is false) to indicate whether you want to wait for the
+Assembly to finish with all encoding results present before the callback is called. If
+waitForCompletion is true, this SDK will poll for status updates and return when all encoding work
+is done.
 
 Check example #1 above for more information.
 

--- a/lib/transloadit/Transloadit.php
+++ b/lib/transloadit/Transloadit.php
@@ -14,9 +14,10 @@ class Transloadit{
 
   public function request($options = array(), $execute = true) {
     $options = $options + array(
-      'key'      => $this->key,
-      'secret'   => $this->secret,
-      'endpoint' => $this->endpoint,
+      'key'               => $this->key,
+      'secret'            => $this->secret,
+      'endpoint'          => $this->endpoint,
+      'waitForCompletion' => false,
     );
     $request = new TransloaditRequest($options);
     return ($execute)
@@ -86,23 +87,9 @@ class Transloadit{
   }
 
   public function createAssembly($options) {
-    // Before sending our assembly, we ask transloadit to recommend a
-    // particular non-busy instance. This is not required, but it
-    // can help to get our assembly executed faster.
-    $boredInstance = $this->request(array(
-      'method' => 'GET',
-      'path'   => '/instances/bored',
-    ), true);
-
-    $error = $boredInstance->error();
-    if ($error) {
-      return $error;
-    }
-
     return $this->request($options + array(
-      'method'   => 'POST',
-      'path'     => '/assemblies',
-      'endpoint' => 'https://' . $boredInstance->data['api2_host'],
+      'method' => 'POST',
+      'path'   => '/assemblies',
     ));
   }
 

--- a/lib/transloadit/TransloaditRequest.php
+++ b/lib/transloadit/TransloaditRequest.php
@@ -101,7 +101,17 @@ class TransloaditRequest extends CurlRequest{
         return $response;
       }
 
-      sleep(1);
+      if (isset($response->data['error']) && !empty($response->data['error'])) {
+        return $response;
+      }
+
+      if ($response->data['ok'] === 'ASSEMBLY_UPLOADING' || $response->data['ok'] === 'ASSEMBLY_EXECUTING') {
+        sleep(1);
+        continue;
+      }
+
+      // If this is an unknown Assembly completion state, return anyway.
+      return $response;
     }
   }
 }

--- a/test/simple/TransloaditTest.php
+++ b/test/simple/TransloaditTest.php
@@ -23,32 +23,15 @@ class TransloaditTest extends \PHPUnit_Framework_TestCase{
     ));
 
     $assembly = $this->getMock('transloadit\\TransloaditResponse');
-    $boredInstance = $this->getMock('transloadit\\TransloaditResponse');
-    $boredInstance->data = array('api2_host' => 'super.transloadit.com');
 
     $options = array('foo' => 'bar');
 
     $transloadit
       ->expects($this->at(0))
       ->method('request')
-      ->with($this->equalTo(array(
-        'method' => 'GET',
-        'path' => '/instances/bored',
-      )))
-      ->will($this->returnValue($boredInstance));
-
-    $boredInstance
-      ->expects($this->at(0))
-      ->method('error')
-      ->will($this->returnValue(false));
-
-    $transloadit
-      ->expects($this->at(1))
-      ->method('request')
       ->with($this->equalTo($options + array(
         'method'   => 'POST',
         'path'     => '/assemblies',
-        'endpoint' => 'https://' . $boredInstance->data['api2_host'],
       )))
       ->will($this->returnValue($assembly));
 

--- a/test/system/Transloadit/TransloaditCreateAssemblyWaitForCompletionTest.php
+++ b/test/system/Transloadit/TransloaditCreateAssemblyWaitForCompletionTest.php
@@ -1,0 +1,36 @@
+<?php
+use transloadit\Transloadit;
+
+class TransloaditCreateAssemblyWaitForCompletionTest extends \PHPUnit_Framework_TestCase{
+  public function setUp() {
+    if (!defined('TEST_ACCOUNT_KEY')) {
+      $this->markTestSkipped(
+        'Have a look at test/config.php.template to get this test to run.'
+      );
+      return;
+    }
+
+    // @todo Load config from git excluded config file
+    $this->transloadit = new Transloadit(array(
+      'key' => TEST_ACCOUNT_KEY,
+      'secret' => TEST_ACCOUNT_SECRET,
+    ));
+  }
+  public function testRoot() {
+    $response = $this->transloadit->createAssembly(array(
+      'files' => array(TEST_FIXTURE_DIR.'/image-resize-robot.jpg'),
+      'params' => array(
+        'steps' => array(
+          'resize' => array(
+            'robot' => '/image/resize',
+            'width' => 100,
+            'height' => 100,
+            'result' => true,
+          ),
+        ),
+      ),
+      'waitForCompletion' => true
+    ));
+    $this->assertEquals('ASSEMBLY_COMPLETED', $response->data['ok']);
+  }
+}


### PR DESCRIPTION
The node-sdk supports this. All SDKs should.

Also added a test and made sure the existing tests pass.

Closes #26.