### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,8 @@ All of the following will cause an error string to be returned:
 - The Transloadit response JSON contains an `{"error": "..."}` key
 - A malformed response was received
 
+***Note***: You will need to set waitForCompletion = True in the $Transloadit->createAssembly($options) function call.  
+
 ## Contributing
 
 Feel free to fork this project. We will happily merge bug fixes or other small


### PR DESCRIPTION
If they don't set waitForCompletion to true then the error() function will erroneously return false because the Assembly will be in the ASSEMBLY_EXECUTING state and no error key will be present.