### PR TITLE
Replace Composer install action and harden action refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,15 @@ jobs:
           - highest
     name: PHP ${{ matrix.php }} - ${{ matrix.dependencies }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
       - name: Install tsx
         run: npm install -g tsx
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: ${{ matrix.php }}
           tools: php-cs-fixer, phpunit
@@ -73,7 +73,7 @@ jobs:
           TEST_NODE_PARITY: 1
       - name: Publish Coverage Report
         if: github.event_name == 'pull_request' && matrix.php == '8.1' && matrix.dependencies == 'locked'
-        uses: lucassabreu/comment-coverage-clover@v0.13.0
+        uses: lucassabreu/comment-coverage-clover@03f6635d40eed0594269416270abb9f72dfeae4b # v0.16.0
         with:
           file: ./build/logs/clover.xml
           with-table: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,24 @@ jobs:
           php-version: ${{ matrix.php }}
           tools: php-cs-fixer, phpunit
           coverage: ${{ matrix.php == '8.1' && matrix.dependencies == 'locked' && 'xdebug' || 'none' }}
-      - uses: ramsey/composer-install@v3
-        with:
-          dependency-versions: ${{ matrix.dependencies }}
-          composer-options: '--ignore-platform-reqs'
+      - name: Install Composer dependencies
+        run: |
+          set -euo pipefail
+          case "${{ matrix.dependencies }}" in
+            locked)
+              composer install --no-interaction --prefer-dist --ignore-platform-reqs
+              ;;
+            lowest)
+              composer update --no-interaction --prefer-dist --ignore-platform-reqs --prefer-lowest
+              ;;
+            highest)
+              composer update --no-interaction --prefer-dist --ignore-platform-reqs
+              ;;
+            *)
+              echo "Unsupported dependency mode: ${{ matrix.dependencies }}" >&2
+              exit 1
+              ;;
+          esac
       - name: Test with Coverage
         if: matrix.php == '8.1' && matrix.dependencies == 'locked'
         run: |


### PR DESCRIPTION
Why

Reduce GitHub Actions supply-chain exposure by replacing a convenience Composer action with explicit Composer commands.

What changed

- Removes `ramsey/composer-install`.
- Runs `composer install` for locked dependencies and `composer update` for lowest/highest dependency matrix entries.
- Preserves `--ignore-platform-reqs`.

Validation

- Ruby YAML parse for `.github/workflows/ci.yml`
- `git diff --check`

Additional action reference hardening included here:

- Updates GitHub-owned actions in touched workflows to current major tags.
- Pins retained third-party actions in touched workflows to reviewed commit SHAs, keeping version comments beside each SHA.
